### PR TITLE
feat: 이미지 상세 보기 + AI 에이전트 명세 설정

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "npx",
       "runtimeArgs": ["vite"],
       "port": 5173
+    },
+    {
+      "name": "Portfolio Preview",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["vite", "preview"],
+      "port": 4173
     }
   ]
 }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,104 @@
+name: Vercel PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - run: npm install -g vercel
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build with Vercel
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.url }}';
+            const body = `🔍 **PR Preview**: ${url}`;
+
+            // Find existing bot comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('PR Preview')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - run: npm install -g vercel
+
+      - name: Remove preview deployments
+        run: |
+          # List deployments and delete ones matching this PR's branch
+          vercel ls --token=${{ secrets.VERCEL_TOKEN }} --meta gitBranch=${{ github.head_ref }} 2>/dev/null | \
+            grep -oP 'https://\S+' | while read url; do
+              vercel rm "$url" --yes --token=${{ secrets.VERCEL_TOKEN }} 2>/dev/null || true
+            done
+
+      - name: Update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('PR Preview')
+            );
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: '🔍 **PR Preview**: 삭제됨 (PR closed)',
+              });
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,14 @@
 # Portfolio Project - Agent Rules
 
 ## 개발 워크플로우
-- 새로운 기능/수정 작업 시 반드시 `/issue-worktree` 스킬을 사용할 것
-- 워크트리를 통해 다른 브랜치 작업과 격리된 환경에서 진행
-
-## 브랜치 규칙
-- 형식: `feat/<이슈번호>-<간단한-설명>` (e.g. `feat/3-image-lightbox`)
+- 기능 추가/버그 수정 시 이슈 기반 브랜치에서 작업할 것
+- 브랜치 형식: `feat/<이슈번호>-<간단한-설명>` (e.g. `feat/3-image-lightbox`)
 - base 브랜치: `main`
+
+## 빌드 & 테스트
+- `npm run dev` — 개발 서버
+- `npm run build` — 프로덕션 빌드
+- `npm run preview` — 빌드 결과 프리뷰
 
 ## 커밋 컨벤션
 - `feat:` 새로운 기능
@@ -20,8 +22,5 @@
 - 본문: Summary, Test plan 섹션 포함
 - `Closes #이슈번호`로 이슈 자동 닫기
 
-## 기술 스택
-- React 18 + TypeScript + Vite
-- Tailwind CSS v4
-- Radix UI + Motion (framer-motion)
-- GitHub Pages 배포 (base: /portfolio/)
+## 배포
+- GitHub Pages (base path: /portfolio/)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Portfolio Project - Agent Rules
+
+## 개발 워크플로우
+- 새로운 기능/수정 작업 시 반드시 `/issue-worktree` 스킬을 사용할 것
+- 워크트리를 통해 다른 브랜치 작업과 격리된 환경에서 진행
+
+## 브랜치 규칙
+- 형식: `feat/<이슈번호>-<간단한-설명>` (e.g. `feat/3-image-lightbox`)
+- base 브랜치: `main`
+
+## 커밋 컨벤션
+- `feat:` 새로운 기능
+- `fix:` 버그 수정
+- `chore:` 빌드/설정 변경
+- `refactor:` 리팩토링
+- 이슈 번호 참조: `(#이슈번호)`
+
+## PR 규칙
+- 제목: 70자 이내, 한글 OK
+- 본문: Summary, Test plan 섹션 포함
+- `Closes #이슈번호`로 이슈 자동 닫기
+
+## 기술 스택
+- React 18 + TypeScript + Vite
+- Tailwind CSS v4
+- Radix UI + Motion (framer-motion)
+- GitHub Pages 배포 (base: /portfolio/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/app/components/ClickableImage.tsx
+++ b/src/app/components/ClickableImage.tsx
@@ -18,7 +18,7 @@ export function ClickableImage({ className, src, alt, ...props }: ClickableImage
         onClick={() => setOpen(true)}
         {...props}
       />
-      <ImageLightbox open={open} onOpenChange={setOpen} src={src} alt={alt} />
+      <ImageLightbox open={open} onClose={() => setOpen(false)} src={src} alt={alt} />
     </>
   );
 }

--- a/src/app/components/ClickableImage.tsx
+++ b/src/app/components/ClickableImage.tsx
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { cn } from "./ui/utils";
+import { ImageLightbox } from "./ImageLightbox";
+
+interface ClickableImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
+
+export function ClickableImage({ className, src, alt, ...props }: ClickableImageProps) {
+  const [open, setOpen] = useState(false);
+
+  if (!src) return <img className={className} src={src} alt={alt} {...props} />;
+
+  return (
+    <>
+      <img
+        src={src}
+        alt={alt}
+        className={cn("cursor-pointer hover:brightness-[1.03] transition-[filter]", className)}
+        onClick={() => setOpen(true)}
+        {...props}
+      />
+      <ImageLightbox open={open} onOpenChange={setOpen} src={src} alt={alt} />
+    </>
+  );
+}

--- a/src/app/components/Diagrams.tsx
+++ b/src/app/components/Diagrams.tsx
@@ -1,4 +1,5 @@
 import { FadeInView } from "./ParallaxSection";
+import { ClickableImage } from "./ClickableImage";
 
 /* ─── Architecture Layer Diagram ─── */
 export function LayerDiagram({
@@ -421,7 +422,7 @@ export function SyncFlowDiagram({ description, screenshotSrc }: { description?: 
           {/* 오른쪽: 앱 스크린샷 */}
           <div className="flex justify-center">
             {screenshotSrc
-              ? <img src={screenshotSrc} alt="실시간 채팅 스크린샷" className="w-full max-w-[240px] rounded-2xl" />
+              ? <ClickableImage src={screenshotSrc} alt="실시간 채팅 스크린샷" className="w-full max-w-[240px] rounded-2xl" />
               : <AppScreenshotPlaceholder label="실시간 채팅 스크린샷" />}
           </div>
         </div>

--- a/src/app/components/ImageLightbox.tsx
+++ b/src/app/components/ImageLightbox.tsx
@@ -1,0 +1,35 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+
+interface ImageLightboxProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  src: string;
+  alt?: string;
+}
+
+export function ImageLightbox({ open, onOpenChange, src, alt }: ImageLightboxProps) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 duration-200" />
+        <DialogPrimitive.Content className="fixed top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-[90vw] h-[90vh] flex items-center justify-center data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 duration-200 outline-none">
+          <DialogPrimitive.Title className="sr-only">
+            {alt || "이미지 상세 보기"}
+          </DialogPrimitive.Title>
+
+          <img
+            src={src}
+            alt={alt || ""}
+            className="max-h-full max-w-full object-contain rounded-lg"
+          />
+
+          <DialogPrimitive.Close className="fixed top-4 right-4 z-50 p-2 rounded-full bg-black/40 text-white hover:bg-black/60 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50">
+            <XIcon size={20} />
+            <span className="sr-only">닫기</span>
+          </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/src/app/components/ImageLightbox.tsx
+++ b/src/app/components/ImageLightbox.tsx
@@ -1,35 +1,63 @@
-import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { XIcon } from "lucide-react";
 
 interface ImageLightboxProps {
   open: boolean;
-  onOpenChange: (open: boolean) => void;
+  onClose: () => void;
   src: string;
   alt?: string;
 }
 
-export function ImageLightbox({ open, onOpenChange, src, alt }: ImageLightboxProps) {
-  return (
-    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
-      <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 duration-200" />
-        <DialogPrimitive.Content className="fixed top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-[90vw] h-[90vh] flex items-center justify-center data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 duration-200 outline-none">
-          <DialogPrimitive.Title className="sr-only">
-            {alt || "이미지 상세 보기"}
-          </DialogPrimitive.Title>
+export function ImageLightbox({ open, onClose, src, alt }: ImageLightboxProps) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose]
+  );
 
-          <img
-            src={src}
-            alt={alt || ""}
-            className="max-h-full max-w-full object-contain rounded-lg"
-          />
+  useEffect(() => {
+    if (open) {
+      document.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [open, handleKeyDown]);
 
-          <DialogPrimitive.Close className="fixed top-4 right-4 z-50 p-2 rounded-full bg-black/40 text-white hover:bg-black/60 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50">
-            <XIcon size={20} />
-            <span className="sr-only">닫기</span>
-          </DialogPrimitive.Close>
-        </DialogPrimitive.Content>
-      </DialogPrimitive.Portal>
-    </DialogPrimitive.Root>
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-label={alt || "이미지 상세 보기"}
+    >
+      {/* Overlay */}
+      <div
+        className="absolute inset-0 bg-black/90"
+        onClick={onClose}
+      />
+
+      {/* Image */}
+      <img
+        src={src}
+        alt={alt || ""}
+        className="relative z-10 max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-[0_0_40px_rgba(255,255,255,0.08)]"
+      />
+
+      {/* Close button */}
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 z-10 p-2 rounded-full bg-black/40 text-white hover:bg-black/60 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
+      >
+        <XIcon size={20} />
+        <span className="sr-only">닫기</span>
+      </button>
+    </div>,
+    document.body
   );
 }

--- a/src/app/components/ImageLightbox.tsx
+++ b/src/app/components/ImageLightbox.tsx
@@ -116,7 +116,7 @@ export function ImageLightbox({ open, onClose, src, alt }: ImageLightboxProps) {
 
       {/* Image container */}
       <div
-        className="relative z-10 max-h-[90vh] max-w-[90vw] overflow-hidden"
+        className="relative z-10"
         onWheel={handleWheel}
       >
         <img
@@ -126,6 +126,7 @@ export function ImageLightbox({ open, onClose, src, alt }: ImageLightboxProps) {
           className="max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-[0_0_40px_rgba(255,255,255,0.08)] select-none"
           style={{
             transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
+            transformOrigin: "center center",
             cursor: scale > 1 ? (isDragging ? "grabbing" : "grab") : "zoom-in",
             transition: isDragging ? "none" : "transform 0.2s ease-out",
           }}

--- a/src/app/components/ImageLightbox.tsx
+++ b/src/app/components/ImageLightbox.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
-import { XIcon } from "lucide-react";
+import { XIcon, ZoomInIcon, ZoomOutIcon, RotateCcwIcon } from "lucide-react";
 
 interface ImageLightboxProps {
   open: boolean;
@@ -9,12 +9,33 @@ interface ImageLightboxProps {
   alt?: string;
 }
 
+const MIN_SCALE = 1;
+const MAX_SCALE = 5;
+const ZOOM_STEP = 0.3;
+
 export function ImageLightbox({ open, onClose, src, alt }: ImageLightboxProps) {
+  const [scale, setScale] = useState(1);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStart = useRef({ x: 0, y: 0 });
+  const translateStart = useRef({ x: 0, y: 0 });
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  const resetTransform = useCallback(() => {
+    setScale(1);
+    setTranslate({ x: 0, y: 0 });
+  }, []);
+
+  const handleClose = useCallback(() => {
+    resetTransform();
+    onClose();
+  }, [onClose, resetTransform]);
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") handleClose();
     },
-    [onClose]
+    [handleClose]
   );
 
   useEffect(() => {
@@ -28,6 +49,57 @@ export function ImageLightbox({ open, onClose, src, alt }: ImageLightboxProps) {
     };
   }, [open, handleKeyDown]);
 
+  // Wheel zoom on the image
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setScale((prev) => {
+      const delta = e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP;
+      return Math.min(MAX_SCALE, Math.max(MIN_SCALE, prev + delta));
+    });
+  }, []);
+
+  // Mouse drag for panning
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    setIsDragging(true);
+    dragStart.current = { x: e.clientX, y: e.clientY };
+    translateStart.current = { ...translate };
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, [translate]);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    if (!isDragging) return;
+    const dx = e.clientX - dragStart.current.x;
+    const dy = e.clientY - dragStart.current.y;
+    setTranslate({
+      x: translateStart.current.x + dx,
+      y: translateStart.current.y + dy,
+    });
+  }, [isDragging]);
+
+  const handlePointerUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  // Double-click to toggle zoom
+  const handleDoubleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (scale > 1) {
+      resetTransform();
+    } else {
+      setScale(2.5);
+    }
+  }, [scale, resetTransform]);
+
+  const zoomIn = useCallback(() => {
+    setScale((prev) => Math.min(MAX_SCALE, prev + ZOOM_STEP));
+  }, []);
+
+  const zoomOut = useCallback(() => {
+    setScale((prev) => Math.max(MIN_SCALE, prev - ZOOM_STEP));
+  }, []);
+
   if (!open) return null;
 
   return createPortal(
@@ -39,19 +111,67 @@ export function ImageLightbox({ open, onClose, src, alt }: ImageLightboxProps) {
       {/* Overlay */}
       <div
         className="absolute inset-0 bg-black/90"
-        onClick={onClose}
+        onClick={handleClose}
       />
 
-      {/* Image */}
-      <img
-        src={src}
-        alt={alt || ""}
-        className="relative z-10 max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-[0_0_40px_rgba(255,255,255,0.08)]"
-      />
+      {/* Image container */}
+      <div
+        className="relative z-10 max-h-[90vh] max-w-[90vw] overflow-hidden"
+        onWheel={handleWheel}
+      >
+        <img
+          ref={imageRef}
+          src={src}
+          alt={alt || ""}
+          className="max-h-[90vh] max-w-[90vw] object-contain rounded-lg shadow-[0_0_40px_rgba(255,255,255,0.08)] select-none"
+          style={{
+            transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
+            cursor: scale > 1 ? (isDragging ? "grabbing" : "grab") : "zoom-in",
+            transition: isDragging ? "none" : "transform 0.2s ease-out",
+          }}
+          draggable={false}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onDoubleClick={handleDoubleClick}
+        />
+      </div>
+
+      {/* Controls */}
+      <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-10 flex items-center gap-2 px-3 py-2 rounded-full bg-black/60 backdrop-blur-sm">
+        <button
+          onClick={zoomOut}
+          disabled={scale <= MIN_SCALE}
+          className="p-1.5 rounded-full text-white hover:bg-white/15 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          aria-label="축소"
+        >
+          <ZoomOutIcon size={18} />
+        </button>
+        <span className="text-white/80 text-[12px] font-[500] min-w-[3em] text-center select-none">
+          {Math.round(scale * 100)}%
+        </span>
+        <button
+          onClick={zoomIn}
+          disabled={scale >= MAX_SCALE}
+          className="p-1.5 rounded-full text-white hover:bg-white/15 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          aria-label="확대"
+        >
+          <ZoomInIcon size={18} />
+        </button>
+        <div className="w-px h-4 bg-white/20" />
+        <button
+          onClick={resetTransform}
+          disabled={scale === 1 && translate.x === 0 && translate.y === 0}
+          className="p-1.5 rounded-full text-white hover:bg-white/15 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+          aria-label="원래 크기로"
+        >
+          <RotateCcwIcon size={18} />
+        </button>
+      </div>
 
       {/* Close button */}
       <button
-        onClick={onClose}
+        onClick={handleClose}
         className="absolute top-4 right-4 z-10 p-2 rounded-full bg-black/40 text-white hover:bg-black/60 transition-colors focus:outline-none focus:ring-2 focus:ring-white/50"
       >
         <XIcon size={20} />

--- a/src/app/components/ProjectFiltee.tsx
+++ b/src/app/components/ProjectFiltee.tsx
@@ -1,5 +1,6 @@
 import { FadeInView } from "./ParallaxSection";
 import { ProjectHeader } from "./ProjectHeader";
+import { ClickableImage } from "./ClickableImage";
 import {
   FeatureGrid,
   LayerDiagram,
@@ -296,7 +297,7 @@ export function ProjectFiltee() {
 
               {/* 오른쪽: 앱 스크린샷 */}
               <div className="flex justify-center">
-                <img
+                <ClickableImage
                   src={filterScreenshot}
                   alt="필터 제작 스크린샷"
                   className="w-full max-w-[240px] rounded-2xl"
@@ -533,7 +534,7 @@ export function ProjectFiltee() {
 
               {/* 오른쪽: 앱 스크린샷 */}
               <div className="flex items-center justify-center">
-                <img
+                <ClickableImage
                   src={chatSearchScreenshot}
                   alt="채팅 검색 스크린샷"
                   className="w-full max-w-[240px] rounded-2xl"

--- a/src/app/components/ProjectHeader.tsx
+++ b/src/app/components/ProjectHeader.tsx
@@ -1,5 +1,6 @@
 import { FadeInView } from "./ParallaxSection";
 import { TechTags, ScreenshotPlaceholder } from "./Diagrams";
+import { ClickableImage } from "./ClickableImage";
 import { Github, ExternalLink } from "lucide-react";
 
 interface ProjectHeaderProps {
@@ -97,7 +98,7 @@ export function ProjectHeader({
         <FadeInView delay={0.2} speed={1.5}>
           <div className="mt-10">
             {screenshotSrc
-              ? <img src={screenshotSrc} alt={screenshotLabel} className="w-full rounded-2xl object-contain" />
+              ? <ClickableImage src={screenshotSrc} alt={screenshotLabel} className="w-full rounded-2xl object-contain" />
               : <ScreenshotPlaceholder label={screenshotLabel} />
             }
           </div>

--- a/src/app/components/ProjectPokit.tsx
+++ b/src/app/components/ProjectPokit.tsx
@@ -1,6 +1,7 @@
 import { FadeInView } from "./ParallaxSection";
 import { ProjectHeader } from "./ProjectHeader";
 import { AppScreenshotPlaceholder, FeatureGrid, LayerDiagram, ProblemSolvingBlock, ScreenshotPlaceholder } from "./Diagrams";
+import { ClickableImage } from "./ClickableImage";
 import pokitPromo from "../../image/포킷표지.png";
 import tuistGraph from "../../image/Tuist Graph — 모듈 의존 관계 시각화.png";
 import linkThumb1 from "../../image/link-thumbnail-1.jpg";
@@ -59,7 +60,7 @@ export function ProjectPokit() {
 
         {/* Tuist Graph */}
         <FadeInView>
-          <img
+          <ClickableImage
             src={tuistGraph}
             alt="Tuist Graph — 모듈 의존 관계 시각화"
             className="w-full rounded-2xl object-contain bg-white p-4"

--- a/src/app/components/ProjectRxCompose.tsx
+++ b/src/app/components/ProjectRxCompose.tsx
@@ -1,6 +1,7 @@
 import { FadeInView } from "./ParallaxSection";
 import { ProjectHeader } from "./ProjectHeader";
 import { FeatureGrid, RxComposeArchitectureDiagram } from "./Diagrams";
+import { ClickableImage } from "./ClickableImage";
 import showpotPromo from "../../image/쇼팟표지.png";
 
 const FEATURES = [
@@ -103,7 +104,7 @@ export function ProjectRxCompose() {
 
           <div className="h-px bg-border mb-5" />
 
-          <img
+          <ClickableImage
             src={showpotPromo}
             alt="ShowPot 앱 스크린샷"
             className="w-full rounded-xl object-contain mb-5"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  base: '/portfolio/',
+  base: process.env.VERCEL ? '/' : '/portfolio/',
   plugins: [
     // The React and Tailwind plugins are both required for Make, even if
     // Tailwind is not being actively used – do not remove them


### PR DESCRIPTION
## Summary
- `ImageLightbox` + `ClickableImage` 컴포넌트로 이미지 상세 보기 기능 추가
- Lightbox 내 이미지 확대/축소(zoom), 드래그 팬, 더블클릭 줌 지원
- `AGENTS.md` + `CLAUDE.md` 심볼릭 링크로 AI 에이전트 워크플로우 표준화
- Vercel PR 프리뷰 배포 자동화 설정

## 변경 내용

### 이미지 Lightbox (#3)
- `ImageLightbox.tsx`: 어두운 오버레이, ESC/X 닫기, 스크롤 줌(1x~5x), 더블클릭 줌 토글, 드래그 팬, 줌 컨트롤 UI
- `ClickableImage.tsx`: img 래퍼 + cursor-pointer + hover brightness
- ProjectHeader, ProjectPokit, ProjectFiltee, ProjectRxCompose, Diagrams에서 img → ClickableImage 교체
- link-thumbnail은 UI 시연용이므로 제외

### AI 명세 (#5)
- `AGENTS.md`: 브랜치/커밋/PR 규칙, 빌드 명령어
- `CLAUDE.md` → `AGENTS.md` 심볼릭 링크

### PR 프리뷰 배포
- `.github/workflows/preview.yml`: Vercel PR 프리뷰 자동 배포 + PR 닫힘 시 자동 삭제
- `vercel.json`: 프리뷰용 Vite 빌드 설정
- `vite.config.ts`: Vercel 환경에서 base path `/` 분기

## Test plan
- [x] 모든 프로젝트 프로모 이미지 클릭 → Lightbox 오픈
- [x] RxCompose 내 ShowPot 적용 사례 이미지 클릭 → Lightbox 오픈
- [x] Lightbox에서 스크롤 → 이미지 확대/축소
- [x] Lightbox에서 더블클릭 → 2.5x 줌 토글
- [x] 확대 상태에서 드래그 → 이미지 패닝
- [x] 줌 컨트롤 버튼 (확대/축소/초기화) 동작 확인
- [x] ESC / 오버레이 클릭 / X 버튼 닫기
- [x] `npm run build` 성공 확인

Closes #3
Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)