### PR TITLE
fix: Repository 버튼 아이콘/텍스트 안 보이는 문제 수정

### DIFF
--- a/src/app/components/design-system.tsx
+++ b/src/app/components/design-system.tsx
@@ -243,7 +243,7 @@ export function IconButton({
   className?: string;
 } & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "className" | "children">) {
   const variantClass = {
-    primary: "bg-foreground text-background hover:opacity-90 transition-opacity",
+    primary: "bg-foreground hover:opacity-90 transition-opacity",
     secondary: "border border-border text-foreground hover:bg-muted transition-colors",
   }[variant];
 
@@ -253,10 +253,13 @@ export function IconButton({
     lg: "gap-3 px-6 py-3 rounded-xl text-base",
   }[size];
 
+  const variantStyle = variant === "primary" ? { color: "var(--background)" } : undefined;
+
   return (
     <a
       href={href}
       className={cn("inline-flex items-center font-medium", variantClass, sizeClass, className)}
+      style={variantStyle}
       {...rest}
     >
       {icon}


### PR DESCRIPTION
## Summary
- `IconButton` 컴포넌트의 `variant="primary"`에서 `text-background`(color)와 `text-sm-md`(font-size)가 `twMerge`에서 충돌하여 색상 클래스가 제거되는 버그 수정
- `text-background` 대신 인라인 스타일 `color: var(--background)`로 변경하여 충돌 회피
- 라이트/다크 모드 모두 정상 동작 확인

## Test plan
- [x] 개발 서버에서 프로젝트 섹션의 Repository 버튼에 GitHub 아이콘과 텍스트가 보이는지 확인
- [x] 다크 모드에서도 동일하게 작동하는지 확인
- [ ] HeroSection, FooterSection의 GitHub/Contact 버튼도 정상인지 확인

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)