### PR TITLE
docs: 워크트리 프리뷰 확인 가이드 추가

### DIFF
--- a/skills/issue-worktree.md
+++ b/skills/issue-worktree.md
@@ -25,6 +25,10 @@ argument-hint: "[작업 설명]"
 - 작업 단위로 의미 있는 커밋을 생성
 - 커밋 메시지 형식: `feat: <설명> (#<이슈번호>)` / `fix:` / `chore:` / `refactor:`
 - 작업 완료 후 `npm run build`로 빌드 확인
+- **UI 변경사항 프리뷰 확인** (필요 시):
+  - `preview_start`로 `Worktree Dev Server` (port 5174) 실행
+  - base path가 `/portfolio/`이므로 `http://localhost:5174/portfolio/`로 이동하여 확인
+  - 워크트리 cwd에서 서버가 실행되므로 워크트리의 변경사항이 반영됨
 
 ## 5. 푸시 및 PR 생성
 - `git push -u origin <브랜치명>`


### PR DESCRIPTION
## Summary
- `/issue-worktree` 스킬의 작업 수행 단계에 워크트리 프리뷰 확인 가이드 추가
- `preview_start`로 Worktree Dev Server (port 5174) 실행하여 워크트리 변경사항을 Claude Preview로 확인할 수 있음을 안내
- base path `/portfolio/` 경로 이동 필요 안내 포함

## Test plan
- [ ] `/issue-worktree` 스킬 문서에 프리뷰 관련 내용이 정상적으로 반영되었는지 확인
- [ ] 워크트리 진입 후 `preview_start`로 프리뷰 정상 동작 확인

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)