### PR TITLE
design: 5개 스킬 기반 Editorial 디자인 전면 개편 (#25)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,13 @@
 
   <!DOCTYPE html>
-  <html lang="en">
+  <html lang="ko">
     <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta name="color-scheme" content="light dark" />
+      <meta name="theme-color" content="#FAF8F4" media="(prefers-color-scheme: light)" />
+      <meta name="theme-color" content="#111009" media="(prefers-color-scheme: dark)" />
+      <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
       <title>김도형 | iOS Developer Portfolio</title>
       <meta name="description" content="더 나은 방향을 향해 한 걸음씩 나아가는 iOS 개발자 김도형의 포트폴리오입니다." />
 
@@ -25,4 +29,3 @@
       <script type="module" src="/src/main.tsx"></script>
     </body>
   </html>
-  

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,6 +8,7 @@ import { ProjectRxCompose } from "./components/ProjectRxCompose";
 import { ProjectFiltee } from "./components/ProjectFiltee";
 import { ProjectPokit } from "./components/ProjectPokit";
 import { ProjectInterest } from "./components/ProjectInterest";
+import { ProjectShowPot } from "./components/ProjectShowPot";
 import { ExperienceSection } from "./components/ExperienceSection";
 import { FooterSection } from "./components/FooterSection";
 import { ScrollSection } from "./components/ParallaxSection";
@@ -48,17 +49,18 @@ function ProjectDivider({
   return (
     <div id={id} ref={containerRef} className="relative h-[150vh]">
       <div className="sticky top-0 h-screen flex items-center">
-        <div className="max-w-5xl mx-auto w-full px-6">
+        <div className="max-w-6xl mx-auto w-full px-6">
           <div className="flex items-end gap-4 mb-6">
             <motion.span
               style={{ opacity: numberOpacity, y: numberY }}
-              className="text-[64px] md:text-[120px] font-black text-primary/10 leading-none"
+              className="text-[64px] md:text-[120px] font-black text-primary/10 leading-none tabular-nums"
+              aria-hidden="true"
             >
               {number}
             </motion.span>
             <motion.h3
               style={{ opacity: titleOpacity, y: titleY }}
-              className="text-[28px] md:text-[40px] font-extrabold tracking-tighter text-foreground pb-3"
+              className="text-[28px] md:text-[40px] font-black tracking-tightest text-foreground pb-3 text-balance"
             >
               {title}
             </motion.h3>
@@ -99,12 +101,13 @@ function ProjectSection({
       <motion.div
         style={{ y: bgY }}
         className="absolute inset-0 pointer-events-none"
+        aria-hidden="true"
       >
         <div className="absolute top-[15%] -right-[80px] w-[300px] h-[300px] rounded-full bg-primary/3 blur-3xl" />
         <div className="absolute bottom-[20%] -left-[60px] w-[250px] h-[250px] rounded-full bg-primary/2 blur-3xl" />
       </motion.div>
 
-      <div className="relative z-10 max-w-5xl mx-auto">
+      <div className="relative z-10 max-w-6xl mx-auto">
         <ScrollSection>
           {children}
         </ScrollSection>
@@ -122,6 +125,7 @@ function ScrollProgress() {
     <motion.div
       style={{ scaleX, transformOrigin: "left" }}
       className="fixed top-0 left-0 right-0 h-[2px] bg-primary z-[60]"
+      aria-hidden="true"
     />
   );
 }
@@ -158,6 +162,11 @@ export default function App() {
         <ProjectDivider id="project-04" number="04" title="인터레스트" />
         <ProjectSection>
           <ProjectInterest />
+        </ProjectSection>
+
+        <ProjectDivider id="project-05" number="05" title="ShowPot" />
+        <ProjectSection bg>
+          <ProjectShowPot />
         </ProjectSection>
       </div>
 

--- a/src/app/components/AboutSection.tsx
+++ b/src/app/components/AboutSection.tsx
@@ -103,14 +103,15 @@ export function AboutSection() {
         <motion.div
           style={{ rotate: accentRotate }}
           className="absolute top-[20%] left-[8%] w-3 h-3 rounded-full border-2 border-primary/20"
+          aria-hidden="true"
         />
         {/* Horizontal line - right */}
-        <div className="absolute top-[40%] right-[5%] w-20 h-px bg-primary/15" />
+        <div className="absolute top-[40%] right-[5%] w-20 h-px bg-primary/15" aria-hidden="true" />
         {/* Filled dot - bottom right */}
-        <div className="absolute bottom-[25%] right-[12%] w-1.5 h-1.5 rounded-full bg-primary/25" />
+        <div className="absolute bottom-[25%] right-[12%] w-1.5 h-1.5 rounded-full bg-primary/25" aria-hidden="true" />
         {/* Plus sign - left */}
         {!isMobile && (
-          <span className="absolute bottom-[40%] left-[15%] text-3xl text-primary/15 leading-none select-none">
+          <span className="absolute bottom-[40%] left-[15%] text-3xl text-primary/15 leading-none select-none" aria-hidden="true">
             +
           </span>
         )}
@@ -123,50 +124,53 @@ export function AboutSection() {
           style={{ y: titleY, opacity: titleOpacity, scale: titleScale }}
           className="mb-16"
         >
-          <SectionHeading accent="primary">
+          <SectionHeading
+            sectionNumber="01"
+            kicker="Section 01 — About"
+          >
             <span className="text-lg font-bold text-primary tracking-tighter">
               iOS Developer
             </span>
           </SectionHeading>
           <div className="flex flex-col md:flex-row md:items-center gap-8 md:gap-12">
             <div className="flex-1 min-w-0">
-              <h2 className="text-8xl md:text-9xl font-bold tracking-tighter leading-tight text-foreground mb-6">
+              <h2 className="text-8xl md:text-9xl font-black tracking-tightest leading-[0.9] text-foreground text-balance mb-6">
                 <span>김도형 </span>
-                <span className="text-[40px] md:text-[60px] font-normal text-muted-foreground">
+                <span className="text-[40px] md:text-[60px] font-light text-muted-foreground">
                   Kim Dohyeong
                 </span>
               </h2>
-              <p className="text-3xl font-normal text-muted-foreground leading-relaxed max-w-2xl tracking-tight">
+              <p className="text-3xl font-light text-muted-foreground leading-relaxed max-w-2xl tracking-tight text-pretty">
                 개발에 대한 꾸준한 고민과 되돌아보는 태도를 바탕으로, 더 나은 방향을
                 향해 한 걸음씩 나아가고 있습니다.
               </p>
             </div>
             <img
               src={profileImg}
-              alt="김도형 프로필 사진"
-              className="w-48 h-64 md:w-56 md:h-72 object-cover rounded-2xl shadow-md shrink-0"
+              alt="iOS 개발자 김도형의 프로필 사진"
+              className="w-48 h-64 md:w-56 md:h-72 object-cover rounded-2xl shadow-editorial shrink-0"
             />
           </div>
         </motion.div>
 
-        {/* Layer 2: Cards */}
-        <div className="grid md:grid-cols-3 gap-5 mb-16">
+        {/* Layer 2: Cards — editorial 비대칭 그리드 (2fr / 1.5fr / 1fr) */}
+        <div className="grid grid-cols-1 md:grid-cols-[2fr_1.5fr_1fr] gap-5 mb-16">
           {VALUES.map((value, i) => (
             <motion.div
               key={value.tag}
               style={{ y: cardYs[i], opacity: cardOpacities[i] }}
             >
-              <div className="p-6 rounded-2xl bg-card border border-border h-full">
+              <div className="p-6 rounded-2xl bg-card border border-border shadow-editorial h-full">
                 <div className="flex items-center gap-2 mb-3">
-                  <div className="w-2 h-2 rounded-full bg-primary" />
-                  <span className="text-base font-bold text-primary">
+                  <div className="w-2 h-2 rounded-full bg-primary" aria-hidden="true" />
+                  <span className="text-xs font-medium text-primary tracking-wide uppercase">
                     {value.tag}
                   </span>
                 </div>
-                <h3 className="text-lg font-bold tracking-tighter text-foreground mb-3 leading-snug">
+                <h3 className="text-lg font-bold tracking-tighter text-foreground mb-3 leading-snug text-balance">
                   {value.title}
                 </h3>
-                <p className="text-base font-normal text-muted-foreground leading-relaxed tracking-snug">
+                <p className="text-base font-normal text-muted-foreground leading-relaxed tracking-snug text-pretty">
                   {value.description}
                 </p>
               </div>
@@ -179,7 +183,7 @@ export function AboutSection() {
           <div className="border-t border-border pt-10">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               {[
-                { label: "Birth", value: "1998.02.05" },
+                { label: "Birth", value: "1998.02.05", tabular: true },
                 {
                   label: "Email",
                   value: "shapekim98@gmail.com",
@@ -189,24 +193,33 @@ export function AboutSection() {
                   label: "GitHub",
                   value: "ShapeKim98",
                   href: "https://github.com/ShapeKim98",
+                  external: true,
                 },
-                { label: "Phone", value: "010-9027-8292" },
+                { label: "Phone", value: "010-9027-8292", href: "tel:+821090278292", tabular: true },
               ].map((item) => (
                 <div key={item.label}>
-                  <p className="text-sm font-medium text-muted-foreground tracking-wider uppercase mb-1.5">
+                  <p className="text-sm font-medium text-muted-foreground tracking-wide uppercase mb-1.5">
                     {item.label}
                   </p>
                   {item.href ? (
                     <a
                       href={item.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-base font-medium text-foreground hover:text-primary transition-colors"
+                      {...(item.external
+                        ? { target: "_blank", rel: "noopener noreferrer" }
+                        : {})}
+                      className={`text-base font-medium text-foreground hover:text-primary transition-colors ${item.tabular ? "tabular-nums" : ""}`}
+                      aria-label={
+                        item.external
+                          ? `${item.label} 프로필 (새 탭)`
+                          : item.label === "Phone"
+                            ? `전화 걸기 ${item.value}`
+                            : `${item.label}로 연락하기`
+                      }
                     >
                       {item.value}
                     </a>
                   ) : (
-                    <p className="text-base font-medium text-foreground">
+                    <p className={`text-base font-medium text-foreground ${item.tabular ? "tabular-nums" : ""}`}>
                       {item.value}
                     </p>
                   )}

--- a/src/app/components/ExperienceSection.tsx
+++ b/src/app/components/ExperienceSection.tsx
@@ -220,23 +220,26 @@ export function ExperienceSection() {
 
       <SectionInner>
         {/* Section Header */}
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
+          Section 03 — Experience
+        </p>
         <SectionPageHeading>Experience</SectionPageHeading>
 
         {/* Company Header */}
         <FadeInView speed={1.3}>
           <div className="mb-12">
             <div className="flex items-center gap-3 mb-3">
-              <Building2 size={20} className="text-primary" />
-              <h3 className="text-4xl font-bold tracking-tight text-foreground">
+              <Building2 size={20} className="text-primary" aria-hidden="true" />
+              <h3 className="text-4xl font-black tracking-tighter text-foreground">
                 미스고(주)
               </h3>
             </div>
             <div className="flex flex-wrap items-center gap-3 text-sm-md font-normal text-muted-foreground mb-4">
-              <span>2025. 08 ~ 2026. 04</span>
+              <span className="tabular-nums">2025. 08 ~ 2026. 04</span>
               <DotSeparator />
               <span>iOS Developer</span>
             </div>
-            <div className="text-md font-normal text-muted-foreground leading-loose max-w-3xl space-y-2">
+            <div className="text-md font-normal text-muted-foreground leading-loose max-w-2xl space-y-2 text-pretty">
               <p>
                 Swift/SwiftUI/UIKit 기반 iOS 개발자로 1인 개발 체제에서 2개 앱의
                 전체 iOS 개발을 단독으로 담당했습니다.

--- a/src/app/components/FooterSection.tsx
+++ b/src/app/components/FooterSection.tsx
@@ -31,31 +31,36 @@ export function FooterSection() {
         <motion.div
           style={{ rotate: accentRotate }}
           className="absolute top-[15%] right-[15%] w-3 h-3 rounded-full border-2 border-primary/15"
+          aria-hidden="true"
         />
-        <div className="absolute bottom-[30%] left-[8%] w-20 h-px bg-primary/10" />
+        <div className="absolute bottom-[30%] left-[8%] w-20 h-px bg-primary/10" aria-hidden="true" />
       </ParallaxAccentLayer>
 
       <SectionInner className="max-w-3xl text-center">
         <FadeInView speed={1.3}>
           <span className="text-sm-md font-medium text-primary tracking-widest uppercase mb-4 block">
-            Contact
+            Contact · 05
           </span>
-          <h2 className="text-6xl md:text-8xl font-extrabold tracking-tighter leading-tight text-foreground mb-6">
+          <h2 className="text-6xl md:text-8xl font-black tracking-tightest leading-[0.9] text-foreground text-balance mb-6">
             Let's Connect
           </h2>
-          <p className="text-lg font-normal text-muted-foreground leading-loose mb-12">
+          <p className="text-lg font-light text-muted-foreground leading-relaxed max-w-xl mx-auto text-pretty mb-12">
             함께 성장하고, 더 나은 서비스를 만들어 나갈 수 있는 기회를 기다리고 있습니다.
           </p>
 
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16">
-            <IconButton href="mailto:shapekim98@gmail.com" variant="primary" size="lg" icon={<Mail size={18} />}>shapekim98@gmail.com</IconButton>
-            <IconButton href="https://github.com/ShapeKim98" variant="secondary" size="lg" icon={<Github size={18} />} target="_blank" rel="noopener noreferrer">GitHub</IconButton>
+            <IconButton href="mailto:shapekim98@gmail.com" variant="primary" size="lg" icon={<Mail size={18} aria-hidden="true" />} aria-label="이메일 보내기">shapekim98@gmail.com</IconButton>
+            <IconButton href="https://github.com/ShapeKim98" variant="secondary" size="lg" icon={<Github size={18} aria-hidden="true" />} target="_blank" rel="noopener noreferrer" aria-label="GitHub 프로필 (새 탭)">GitHub</IconButton>
           </div>
 
-          <div className="flex items-center justify-center gap-2 text-muted-foreground">
-            <Phone size={14} />
+          <a
+            href="tel:+821090278292"
+            className="inline-flex items-center justify-center gap-2 text-muted-foreground hover:text-foreground transition-colors min-h-[44px] tabular-nums"
+            aria-label="전화 걸기 010-9027-8292"
+          >
+            <Phone size={14} aria-hidden="true" />
             <span className="text-sm-md font-normal">010-9027-8292</span>
-          </div>
+          </a>
         </FadeInView>
       </SectionInner>
 

--- a/src/app/components/HeroSection.tsx
+++ b/src/app/components/HeroSection.tsx
@@ -1,39 +1,55 @@
 import { useRef } from "react";
-import { motion, useScroll, useTransform, useSpring } from "motion/react";
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useSpring,
+  useReducedMotion,
+} from "motion/react";
 import { Github, Mail, ChevronDown, Download } from "lucide-react";
 import { Badge, IconButton, ParallaxBlobLayer, ParallaxAccentLayer } from "./design-system";
 
 export function HeroSection() {
   const ref = useRef<HTMLDivElement>(null);
+  const shouldReduce = useReducedMotion() ?? false;
   const { scrollYProgress } = useScroll({
     target: ref,
     offset: ["start start", "end start"],
   });
 
-  const spring = { stiffness: 100, damping: 25, restDelta: 0.001 };
+  const easeEditorial: [number, number, number, number] = [0.23, 1, 0.32, 1];
 
-  // Reduced parallax
-  const rawTitleY = useTransform(scrollYProgress, [0, 1], [0, -150]);
+  // Editorial 스프링 (stiffness 상향, reduced-motion 대응)
+  const spring = { stiffness: 140, damping: 28, restDelta: 0.001 };
+
+  const rawTitleY = useTransform(scrollYProgress, [0, 1], [0, shouldReduce ? 0 : -150]);
   const titleY = useSpring(rawTitleY, spring);
-  const rawSubtitleY = useTransform(scrollYProgress, [0, 1], [0, -100]);
+  const rawSubtitleY = useTransform(scrollYProgress, [0, 1], [0, shouldReduce ? 0 : -100]);
   const subtitleY = useSpring(rawSubtitleY, spring);
-  const rawBgY = useTransform(scrollYProgress, [0, 1], [0, 180]);
+  const rawBgY = useTransform(scrollYProgress, [0, 1], [0, shouldReduce ? 0 : 180]);
   const bgY = useSpring(rawBgY, { stiffness: 80, damping: 22 });
   const bgScale = useTransform(scrollYProgress, [0, 1], [1, 1.15]);
   const opacity = useTransform(scrollYProgress, [0, 0.5], [1, 0]);
   const scale = useTransform(scrollYProgress, [0, 0.6], [1, 0.92]);
-  const blurProgress = useTransform(scrollYProgress, [0.2, 0.55], [0, 10]);
+  const blurProgress = useTransform(scrollYProgress, [0.2, 0.55], [0, shouldReduce ? 0 : 10]);
   const blurFilter = useTransform(blurProgress, (v) => `blur(${v}px)`);
 
   // Foreground accent layer
-  const rawAccentY = useTransform(scrollYProgress, [0, 1], [0, -220]);
+  const rawAccentY = useTransform(scrollYProgress, [0, 1], [0, shouldReduce ? 0 : -220]);
   const accentY = useSpring(rawAccentY, { stiffness: 70, damping: 18 });
-  const accentRotate = useTransform(scrollYProgress, [0, 1], [0, 60]);
+  const accentRotate = useTransform(scrollYProgress, [0, 1], [0, shouldReduce ? 0 : 60]);
+
+  // 진입 모션 (Editorial: duration 0.45, 딜레이 80ms 간격, y 12)
+  const enter = (delay: number) => ({
+    initial: { opacity: 0, y: 12 },
+    animate: { opacity: 1, y: 0 },
+    transition: { duration: shouldReduce ? 0.2 : 0.45, delay, ease: easeEditorial },
+  });
 
   return (
     <section
       ref={ref}
-      className="relative min-h-screen flex items-center justify-center overflow-hidden"
+      className="relative min-h-screen flex items-center overflow-hidden"
     >
       {/* Layer 0: Background decoration - slowest */}
       <ParallaxBlobLayer bgY={bgY} bgScale={bgScale}>
@@ -47,90 +63,84 @@ export function HeroSection() {
         <motion.div
           style={{ rotate: accentRotate }}
           className="absolute top-[15%] left-[10%] w-4 h-4 rounded-full border-2 border-primary/15"
+          aria-hidden="true"
         />
-        <div className="absolute top-[30%] right-[8%] w-24 h-px bg-primary/10" />
+        <div className="absolute top-[30%] right-[8%] w-24 h-px bg-primary/10" aria-hidden="true" />
         <motion.div
           style={{ rotate: accentRotate }}
           className="absolute bottom-[30%] left-[15%] w-2 h-2 rounded-full bg-primary/20"
+          aria-hidden="true"
         />
-        <div className="absolute bottom-[20%] right-[12%] text-2xl text-primary/10 select-none">+</div>
+        <div className="absolute bottom-[20%] right-[12%] text-2xl text-primary/10 select-none" aria-hidden="true">+</div>
       </ParallaxAccentLayer>
 
-      {/* Main content */}
+      {/* Main content — editorial 좌측 정렬 + 비대칭 그리드 */}
       <motion.div
-        style={{
-          opacity,
-          scale,
-          filter: blurFilter,
-        }}
-        className="relative z-10 max-w-4xl mx-auto px-6 text-center"
+        style={{ opacity, scale, filter: blurFilter }}
+        className="relative z-10 w-full max-w-6xl mx-auto px-6 md:px-12"
       >
-        <motion.div style={{ y: titleY }} className="mb-8">
-          <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.2 }}
-            className="inline-block mb-6"
-          >
-            <Badge size="sm" className="tracking-wide">iOS Developer</Badge>
-          </motion.div>
+        <div className="grid grid-cols-1 md:grid-cols-[3fr_2fr] md:gap-12 items-end">
+          {/* Left: 이름 + CTA (주 콘텐츠) */}
+          <motion.div style={{ y: titleY }}>
+            <motion.div {...enter(0)} className="mb-6">
+              <Badge size="sm" className="tracking-wide">iOS Developer</Badge>
+            </motion.div>
 
-          <motion.h1
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.4 }}
-            className="text-8xl md:text-9xl font-extrabold tracking-tightest leading-none text-foreground mb-6"
-          >
-            김도형
-          </motion.h1>
-        </motion.div>
-
-        <motion.div style={{ y: subtitleY }}>
-          <motion.p
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.6 }}
-            className="text-xl md:text-3xl font-normal text-muted-foreground leading-loose tracking-snug max-w-2xl mx-auto mb-12"
-          >
-            더 나은 방향을 향해 한 걸음씩 나아가는
-            <br />
-            iOS 개발자입니다.
-          </motion.p>
-
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.8 }}
-            className="flex items-center justify-center gap-4"
-          >
-            <IconButton href="https://github.com/ShapeKim98" variant="primary" size="md" icon={<Github size={16} />} target="_blank" rel="noopener noreferrer">GitHub</IconButton>
-            <IconButton href="mailto:shapekim98@gmail.com" variant="secondary" size="md" icon={<Mail size={16} />}>Contact</IconButton>
-            <IconButton
-              href={`${import.meta.env.BASE_URL}portfolio.pdf`}
-              variant="secondary"
-              size="md"
-              icon={<Download size={16} />}
-              download="김도형_iOS_포트폴리오.pdf"
-              data-print-hide
+            <motion.h1
+              {...enter(0.08)}
+              className="font-black tracking-tightest leading-[0.85] text-foreground text-balance mb-8"
+              style={{ fontSize: "clamp(3.5rem, 14vw, 9rem)" }}
             >
-              PDF
-            </IconButton>
+              김도형
+            </motion.h1>
+
+            <motion.div
+              {...enter(0.24)}
+              className="flex flex-wrap items-center gap-3"
+            >
+              <IconButton href="https://github.com/ShapeKim98" variant="primary" size="md" icon={<Github size={16} />} target="_blank" rel="noopener noreferrer" aria-label="GitHub 프로필 (새 탭)">GitHub</IconButton>
+              <IconButton href="mailto:shapekim98@gmail.com" variant="secondary" size="md" icon={<Mail size={16} />} aria-label="이메일 보내기">Contact</IconButton>
+              <IconButton
+                href={`${import.meta.env.BASE_URL}portfolio.pdf`}
+                variant="secondary"
+                size="md"
+                icon={<Download size={16} />}
+                download="김도형_iOS_포트폴리오.pdf"
+                data-print-hide
+                aria-label="포트폴리오 PDF 다운로드"
+              >
+                PDF
+              </IconButton>
+            </motion.div>
           </motion.div>
-        </motion.div>
+
+          {/* Right: 서브타이틀 (편집적 오프셋) */}
+          <motion.div style={{ y: subtitleY }} className="mt-8 md:mt-0 md:mb-4">
+            <motion.p
+              {...enter(0.16)}
+              className="text-lg md:text-xl font-light text-muted-foreground leading-relaxed tracking-normal max-w-md text-pretty"
+            >
+              더 나은 방향을 향해 한 걸음씩 나아가는
+              <br />
+              iOS 개발자입니다.
+            </motion.p>
+          </motion.div>
+        </div>
       </motion.div>
 
       {/* Scroll indicator */}
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={{ delay: 1.5 }}
+        transition={{ delay: 1.0, duration: 0.4 }}
         style={{ opacity }}
         className="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 text-muted-foreground"
+        aria-hidden="true"
       >
         <span className="text-xs font-normal tracking-widest uppercase">Scroll</span>
         <motion.div
-          animate={{ y: [0, 8, 0] }}
-          transition={{ duration: 1.5, repeat: Infinity }}
+          animate={shouldReduce ? undefined : { y: [0, 8, 0] }}
+          transition={shouldReduce ? undefined : { duration: 1.5, repeat: Infinity, ease: "easeInOut" }}
         >
           <ChevronDown size={16} />
         </motion.div>

--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Moon, Sun, Menu, X, Download } from "lucide-react";
 
 const NAV_ITEMS = [
@@ -13,6 +13,7 @@ export function Navigation() {
   const [isDark, setIsDark] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const saved = localStorage.getItem("theme");
@@ -28,6 +29,19 @@ export function Navigation() {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
+  // Esc로 모바일 메뉴 닫기 + 토글 버튼으로 포커스 복귀
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMobileOpen(false);
+        menuButtonRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [mobileOpen]);
+
   const toggleTheme = () => {
     setIsDark((prev) => {
       const next = !prev;
@@ -37,16 +51,20 @@ export function Navigation() {
     });
   };
 
+  // 공통 아이콘 버튼 클래스 (44px 터치 타겟, editorial transition)
+  const iconBtnClass =
+    "min-w-[44px] min-h-[44px] inline-flex items-center justify-center rounded-full hover:bg-muted text-muted-foreground hover:text-foreground transition-[background-color,color,transform] duration-150 active:scale-[0.97]";
+
   return (
     <nav
-      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-500 ${
+      className={`fixed top-0 left-0 right-0 z-50 transition-[background-color,border-color,box-shadow,backdrop-filter] duration-300 ${
         scrolled
           ? "bg-background/80 backdrop-blur-xl border-b border-border shadow-sm"
           : "bg-transparent"
       }`}
     >
       <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
-        <div className="w-0" />
+        <div className="w-0" aria-hidden="true" />
 
         {/* Desktop */}
         <div className="hidden md:flex items-center gap-8">
@@ -62,16 +80,18 @@ export function Navigation() {
           <a
             href={`${import.meta.env.BASE_URL}portfolio.pdf`}
             download="김도형_iOS_포트폴리오.pdf"
-            aria-label="Download portfolio PDF"
-            className="p-2 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+            aria-label="포트폴리오 PDF 다운로드"
+            className={iconBtnClass}
           >
-            <Download size={18} />
+            <Download size={18} aria-hidden="true" />
           </a>
           <button
+            type="button"
             onClick={toggleTheme}
-            className="p-2 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+            aria-label={isDark ? "라이트 모드로 전환" : "다크 모드로 전환"}
+            className={iconBtnClass}
           >
-            {isDark ? <Sun size={18} /> : <Moon size={18} />}
+            {isDark ? <Sun size={18} aria-hidden="true" /> : <Moon size={18} aria-hidden="true" />}
           </button>
         </div>
 
@@ -80,29 +100,39 @@ export function Navigation() {
           <a
             href={`${import.meta.env.BASE_URL}portfolio.pdf`}
             download="김도형_iOS_포트폴리오.pdf"
-            aria-label="Download portfolio PDF"
-            className="p-2 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+            aria-label="포트폴리오 PDF 다운로드"
+            className={iconBtnClass}
           >
-            <Download size={18} />
+            <Download size={18} aria-hidden="true" />
           </a>
           <button
+            type="button"
             onClick={toggleTheme}
-            className="p-2 rounded-full hover:bg-muted transition-colors text-muted-foreground"
+            aria-label={isDark ? "라이트 모드로 전환" : "다크 모드로 전환"}
+            className={iconBtnClass}
           >
-            {isDark ? <Sun size={18} /> : <Moon size={18} />}
+            {isDark ? <Sun size={18} aria-hidden="true" /> : <Moon size={18} aria-hidden="true" />}
           </button>
           <button
-            onClick={() => setMobileOpen(!mobileOpen)}
-            className="p-2 rounded-full hover:bg-muted transition-colors text-muted-foreground"
+            ref={menuButtonRef}
+            type="button"
+            onClick={() => setMobileOpen((v) => !v)}
+            aria-label={mobileOpen ? "메뉴 닫기" : "메뉴 열기"}
+            aria-expanded={mobileOpen}
+            aria-controls="mobile-menu-panel"
+            className={iconBtnClass}
           >
-            {mobileOpen ? <X size={20} /> : <Menu size={20} />}
+            {mobileOpen ? <X size={20} aria-hidden="true" /> : <Menu size={20} aria-hidden="true" />}
           </button>
         </div>
       </div>
 
       {/* Mobile menu */}
       {mobileOpen && (
-        <div className="md:hidden bg-background/95 backdrop-blur-xl border-b border-border">
+        <div
+          id="mobile-menu-panel"
+          className="md:hidden bg-background/95 backdrop-blur-xl border-b border-border"
+        >
           <div className="px-6 py-4 flex flex-col gap-3">
             {NAV_ITEMS.map((item) => (
               <a

--- a/src/app/components/ParallaxSection.tsx
+++ b/src/app/components/ParallaxSection.tsx
@@ -1,12 +1,41 @@
 import { useRef } from "react";
-import { motion, useScroll, useTransform, useSpring, type MotionValue } from "motion/react";
+import {
+  motion,
+  useScroll,
+  useTransform,
+  useSpring,
+  useReducedMotion,
+  type MotionValue,
+} from "motion/react";
+
+/**
+ * Editorial 모션 프리셋 훅 — Design Spec v2
+ * - prefers-reduced-motion 시 거리·시간 축소
+ * - 스프링/ease 통일
+ */
+export function useEditorialMotion() {
+  const shouldReduce = useReducedMotion() ?? false;
+  const easeEditorial: [number, number, number, number] = [0.23, 1, 0.32, 1];
+  return {
+    shouldReduce,
+    fadeInTransition: shouldReduce
+      ? { duration: 0.2, ease: "linear" as const }
+      : { duration: 0.45, ease: easeEditorial },
+    fadeDistance: shouldReduce ? 0 : 24,
+    scrollSpring: { stiffness: 140, damping: 28, restDelta: 0.001 } as const,
+    parallaxSpring: { stiffness: 80, damping: 22, restDelta: 0.001 } as const,
+    easeEditorial,
+  };
+}
 
 /**
  * 스프링 기반 스무스 패럴렉스 훅
  */
 function useParallax(scrollYProgress: MotionValue<number>, distance: number) {
-  const y = useTransform(scrollYProgress, [0, 1], [-distance, distance]);
-  return useSpring(y, { stiffness: 120, damping: 30, restDelta: 0.001 });
+  const shouldReduce = useReducedMotion() ?? false;
+  const effective = shouldReduce ? 0 : distance;
+  const y = useTransform(scrollYProgress, [0, 1], [-effective, effective]);
+  return useSpring(y, { stiffness: 140, damping: 28, restDelta: 0.001 });
 }
 
 interface ParallaxSectionProps {
@@ -55,13 +84,15 @@ export function ScrollSection({
   speed?: number;
 }) {
   const ref = useRef<HTMLDivElement>(null);
+  const shouldReduce = useReducedMotion() ?? false;
   const { scrollYProgress } = useScroll({
     target: ref,
     offset: ["start 95%", "start 15%"],
   });
 
-  const rawY = useTransform(scrollYProgress, [0, 1], [40 * speed, 0]);
-  const y = useSpring(rawY, { stiffness: 120, damping: 28, restDelta: 0.001 });
+  const distance = shouldReduce ? 0 : 24 * speed;
+  const rawY = useTransform(scrollYProgress, [0, 1], [distance, 0]);
+  const y = useSpring(rawY, { stiffness: 140, damping: 28, restDelta: 0.001 });
   const opacity = useTransform(scrollYProgress, [0, 0.4], [0, 1]);
 
   return (
@@ -72,7 +103,10 @@ export function ScrollSection({
 }
 
 /**
- * FadeInView: 스프링 기반 진입 애니메이션 (부드러운 강도)
+ * FadeInView: 스프링 기반 진입 애니메이션 (Editorial 튜닝)
+ * - y 거리 24px (축소)
+ * - stiffness 140 / damping 28
+ * - prefers-reduced-motion 대응
  */
 export function FadeInView({
   children,
@@ -88,26 +122,32 @@ export function FadeInView({
   speed?: number;
 }) {
   const ref = useRef<HTMLDivElement>(null);
+  const shouldReduce = useReducedMotion() ?? false;
   const { scrollYProgress } = useScroll({
     target: ref,
     offset: ["start 98%", "start 20%"],
   });
 
   const startPoint = Math.min(delay * 0.15, 0.3);
+  const distance = shouldReduce ? 0 : 24 * speed;
 
   const rawY = useTransform(
     scrollYProgress,
     [startPoint, 0.7 + startPoint * 0.3],
-    [50 * speed, 0]
+    [distance, 0]
   );
   const rawX = useTransform(
     scrollYProgress,
     [startPoint, 0.7 + startPoint * 0.3],
-    direction === "left" ? [-40, 0] : direction === "right" ? [40, 0] : [0, 0]
+    direction === "left"
+      ? [shouldReduce ? 0 : -distance, 0]
+      : direction === "right"
+        ? [shouldReduce ? 0 : distance, 0]
+        : [0, 0]
   );
 
-  const y = useSpring(rawY, { stiffness: 100, damping: 25, restDelta: 0.001 });
-  const x = useSpring(rawX, { stiffness: 100, damping: 25, restDelta: 0.001 });
+  const y = useSpring(rawY, { stiffness: 140, damping: 28, restDelta: 0.001 });
+  const x = useSpring(rawX, { stiffness: 140, damping: 28, restDelta: 0.001 });
   const opacity = useTransform(
     scrollYProgress,
     [startPoint, 0.35 + startPoint * 0.3],
@@ -130,7 +170,7 @@ export function FadeInView({
 }
 
 /**
- * DeepParallax: 지속적 패럴렉스 (부드러운 강도)
+ * DeepParallax: 지속적 패럴렉스 (배경 레이어 — 의도적으로 느린 스프링)
  */
 export function DeepParallax({
   children,
@@ -144,12 +184,16 @@ export function DeepParallax({
   fade?: boolean;
 }) {
   const ref = useRef<HTMLDivElement>(null);
+  const shouldReduce = useReducedMotion() ?? false;
   const { scrollYProgress } = useScroll({
     target: ref,
     offset: ["start end", "end start"],
   });
 
-  const y = useParallax(scrollYProgress, 70 * speed);
+  const distance = shouldReduce ? 0 : 70 * speed;
+  const rawY = useTransform(scrollYProgress, [0, 1], [-distance, distance]);
+  // 배경 레이어는 의도적으로 느린 스프링 (Editorial 깊이감)
+  const y = useSpring(rawY, { stiffness: 80, damping: 22, restDelta: 0.001 });
   const opacity = useTransform(scrollYProgress, [0, 0.15, 0.85, 1], [0, 1, 1, 0]);
 
   return (

--- a/src/app/components/ProfileSection.tsx
+++ b/src/app/components/ProfileSection.tsx
@@ -73,63 +73,67 @@ export function ProfileSection() {
         <motion.div
           style={{ rotate: accentRotate }}
           className="absolute top-[12%] right-[10%] w-3 h-3 rounded-full border-2 border-primary/15"
+          aria-hidden="true"
         />
-        <div className="absolute top-[35%] left-[5%] w-16 h-px bg-primary/12" />
-        <div className="absolute bottom-[20%] right-[8%] w-2 h-2 rounded-full bg-primary/20" />
+        <div className="absolute top-[35%] left-[5%] w-16 h-px bg-primary/12" aria-hidden="true" />
+        <div className="absolute bottom-[20%] right-[8%] w-2 h-2 rounded-full bg-primary/20" aria-hidden="true" />
       </ParallaxAccentLayer>
 
       <SectionInner>
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
+          Section 02 — Profile
+        </p>
         <SectionPageHeading>Profile & Skills</SectionPageHeading>
 
-        {/* Profile Info */}
+        {/* Profile Info — editorial 비대칭 (2fr/3fr) */}
         <FadeInView speed={1.3}>
-          <div className="grid md:grid-cols-2 gap-8 mb-16">
+          <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] gap-8 mb-16">
             {/* Left - Info */}
-            <div className="p-8 rounded-2xl bg-card border border-border">
+            <div className="p-8 rounded-2xl bg-card border border-border shadow-editorial">
               <div className="mb-6">
-                <h3 className="text-4xl font-bold tracking-tight text-foreground">김도형</h3>
-                <p className="text-base font-normal text-muted-foreground">1998.02.05</p>
+                <h3 className="text-4xl font-black tracking-tighter text-foreground">김도형</h3>
+                <p className="text-base font-normal text-muted-foreground tabular-nums">1998.02.05</p>
               </div>
               <div className="space-y-3">
                 <InfoRow icon={Mail} label="Email" value="shapekim98@gmail.com" href="mailto:shapekim98@gmail.com" />
-                <InfoRow icon={Github} label="GitHub" value="ShapeKim98" href="https://github.com/ShapeKim98" />
-                <InfoRow icon={Phone} label="Phone" value="010-9027-8292" />
+                <InfoRow icon={Github} label="GitHub" value="ShapeKim98" href="https://github.com/ShapeKim98" external />
+                <InfoRow icon={Phone} label="Phone" value="010-9027-8292" href="tel:+821090278292" tabular />
                 <InfoRow icon={GraduationCap} label="학력" value="세종대학교 컴퓨터공학과 졸업 (2024.08)" />
               </div>
             </div>
 
             {/* Right - Award */}
             <div className="space-y-6">
-              <div className="p-8 rounded-2xl bg-card border border-border">
+              <div className="p-8 rounded-2xl bg-card border border-border shadow-editorial">
                 <div className="flex items-center gap-3 mb-4">
-                  <Trophy size={20} className="text-primary" />
+                  <Trophy size={20} className="text-primary" aria-hidden="true" />
                   <h3 className="text-2xl font-bold tracking-tight text-foreground">수상</h3>
                 </div>
                 <div className="p-4 rounded-xl bg-muted/50">
-                  <p className="text-md font-semibold text-foreground mb-1">
+                  <p className="text-md font-semibold text-foreground mb-1 text-balance">
                     세종대학교 소프트웨어융합대학 해커톤
                   </p>
-                  <p className="text-sm-md font-medium text-primary mb-2">2등 총장상 · 2024.05</p>
-                  <p className="text-sm-md font-normal text-muted-foreground leading-loose">
+                  <p className="text-sm-md font-medium text-primary mb-2 tabular-nums">2등 총장상 · 2024.05</p>
+                  <p className="text-sm-md font-normal text-muted-foreground leading-loose text-pretty">
                     당일 제시되는 3개의 키워드로 아이디어를 기획하고 MVP 개발하는 해커톤(무박 2일). 서핑 지역에 대한 정보와 레슨 매칭, 조난 구조 요청을 보낼 수 있는 서비스로써, iOS, WatchOS 어플리케이션 개발을 담당했습니다.
                   </p>
                 </div>
               </div>
 
-              <div className="p-8 rounded-2xl bg-card border border-border">
+              <div className="p-8 rounded-2xl bg-card border border-border shadow-editorial">
                 <div className="flex items-center gap-3 mb-4">
-                  <Users size={20} className="text-primary" />
+                  <Users size={20} className="text-primary" aria-hidden="true" />
                   <h3 className="text-2xl font-bold tracking-tight text-foreground">활동</h3>
                 </div>
                 <div className="space-y-4">
                   {ACTIVITIES.map((act) => (
                     <div key={act.title} className="flex gap-4">
-                      <span className="text-sm font-medium text-muted-foreground whitespace-nowrap mt-0.5 min-w-[120px]">
+                      <span className="text-sm font-medium text-muted-foreground whitespace-nowrap mt-0.5 min-w-[140px] tabular-nums">
                         {act.period}
                       </span>
                       <div>
-                        <p className="text-base font-semibold text-foreground">{act.title}</p>
-                        <p className="text-sm-md font-normal text-muted-foreground mt-0.5">{act.desc}</p>
+                        <p className="text-base font-semibold text-foreground text-balance">{act.title}</p>
+                        <p className="text-sm-md font-normal text-muted-foreground mt-0.5 text-pretty">{act.desc}</p>
                       </div>
                     </div>
                   ))}
@@ -141,8 +145,8 @@ export function ProfileSection() {
 
         {/* Skills */}
         <FadeInView delay={0.1} speed={1.4}>
-          <div className="p-8 md:p-10 rounded-2xl bg-card border border-border">
-            <h3 className="text-3xl font-bold tracking-tight text-foreground mb-8">
+          <div className="p-8 md:p-10 rounded-2xl bg-card border border-border shadow-editorial">
+            <h3 className="text-3xl font-black tracking-tighter text-foreground mb-8">
               기술 스택
             </h3>
             <div className="space-y-8">
@@ -187,27 +191,37 @@ function InfoRow({
   label,
   value,
   href,
+  external,
+  tabular,
 }: {
   icon: React.ComponentType<{ size?: number; className?: string }>;
   label: string;
   value: string;
   href?: string;
+  external?: boolean;
+  tabular?: boolean;
 }) {
   return (
     <div className="flex items-center gap-3">
-      <Icon size={16} className="text-muted-foreground shrink-0" />
+      <Icon size={16} className="text-muted-foreground shrink-0" aria-hidden="true" />
       <span className="text-sm font-medium text-muted-foreground min-w-[50px]">{label}</span>
       {href ? (
         <a
           href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-base font-normal text-primary hover:underline"
+          {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+          className={`text-base font-normal text-primary hover:underline ${tabular ? "tabular-nums" : ""}`}
+          aria-label={
+            external
+              ? `${label} 프로필 (새 탭)`
+              : label === "Phone"
+                ? `전화 걸기 ${value}`
+                : `${label}로 연락하기`
+          }
         >
           {value}
         </a>
       ) : (
-        <span className="text-base font-normal text-foreground">{value}</span>
+        <span className={`text-base font-normal text-foreground ${tabular ? "tabular-nums" : ""}`}>{value}</span>
       )}
     </div>
   );

--- a/src/app/components/ProjectHeader.tsx
+++ b/src/app/components/ProjectHeader.tsx
@@ -41,14 +41,14 @@ export function ProjectHeader({
     <div className="mb-16" data-print-keep>
       <FadeInView speed={1.3}>
         <div className="flex items-center gap-3 mb-4">
-          <span className="text-8xl md:text-[64px] font-black text-primary/10 leading-none">
+          <span className="text-8xl md:text-[64px] font-black text-primary/10 leading-none tabular-nums" aria-hidden="true">
             {index}
           </span>
           <div>
-            <span className="text-xs font-medium text-primary tracking-widest uppercase">
+            <span className="text-xs font-medium text-primary tracking-wide uppercase">
               {type === "library" ? "Open Source Library" : "Project"}
             </span>
-            <h3 className="text-5xl md:text-7xl font-extrabold tracking-tighter text-foreground leading-tight">
+            <h3 className="text-5xl md:text-7xl font-black tracking-tightest text-foreground leading-[0.9] text-balance">
               {title}
             </h3>
           </div>
@@ -56,23 +56,23 @@ export function ProjectHeader({
       </FadeInView>
 
       <FadeInView delay={0.1} speed={1.4}>
-        <p className="text-xl font-medium text-foreground mb-2">{subtitle}</p>
+        <p className="text-xl font-medium text-foreground mb-2 text-balance">{subtitle}</p>
         <div className="flex flex-wrap items-center gap-4 text-sm-md font-normal text-muted-foreground mb-6">
-          <span>{period}</span>
+          <span className="tabular-nums">{period}</span>
           <DotSeparator />
           <span>{team}</span>
           <DotSeparator />
           <span>담당: {role}</span>
         </div>
 
-        <p className="text-md font-normal text-muted-foreground leading-loose max-w-3xl mb-6">
+        <p className="text-md font-normal text-muted-foreground leading-loose max-w-2xl mb-6 text-pretty">
           {description}
         </p>
 
         <div className="flex flex-wrap items-center gap-3 mb-8">
-          <IconButton href={githubUrl} variant="primary" size="sm" icon={<Github size={14} />} target="_blank" rel="noopener noreferrer">Repository</IconButton>
+          <IconButton href={githubUrl} variant="primary" size="sm" icon={<Github size={14} aria-hidden="true" />} target="_blank" rel="noopener noreferrer" aria-label={`${title} GitHub 저장소 (새 탭)`}>Repository</IconButton>
           {appStoreUrl && (
-            <IconButton href={appStoreUrl} variant="secondary" size="sm" icon={<ExternalLink size={14} />} target="_blank" rel="noopener noreferrer">App Store</IconButton>
+            <IconButton href={appStoreUrl} variant="secondary" size="sm" icon={<ExternalLink size={14} aria-hidden="true" />} target="_blank" rel="noopener noreferrer" aria-label={`${title} App Store (새 탭)`}>App Store</IconButton>
           )}
         </div>
 

--- a/src/app/components/SectionIndicator.tsx
+++ b/src/app/components/SectionIndicator.tsx
@@ -17,6 +17,7 @@ const SECTIONS: SectionItem[] = [
   { id: "project-02", label: "02  Filtee", kind: "sub" },
   { id: "project-03", label: "03  Pokit", kind: "sub" },
   { id: "project-04", label: "04  인터레스트", kind: "sub" },
+  { id: "project-05", label: "05  ShowPot", kind: "sub" },
   { id: "contact", label: "Contact", kind: "main" },
 ];
 
@@ -87,15 +88,16 @@ export function SectionIndicator() {
             key={section.id}
             type="button"
             onClick={() => handleClick(section.id)}
-            className={`group pointer-events-auto flex items-center justify-end gap-3 ${
+            className={`group pointer-events-auto relative flex items-center justify-end gap-3 min-h-[44px] ${
               isSub ? "pl-4" : ""
             }`}
-            aria-label={`Go to ${section.label}`}
-            aria-current={isActive ? "true" : undefined}
+            aria-label={`${section.label} 섹션으로 이동`}
+            aria-current={isActive ? "location" : undefined}
           >
             {/* Label: active면 상시, 아니면 hover에서만 */}
             <span
-              className={`text-right tracking-snug whitespace-nowrap transition-all duration-300 ${
+              aria-hidden={!isActive}
+              className={`text-right tracking-snug whitespace-nowrap transition-[opacity,transform,color] duration-200 ${
                 isSub ? "text-xs font-medium" : "text-sm font-semibold"
               } ${
                 isActive
@@ -108,7 +110,7 @@ export function SectionIndicator() {
 
             {/* Dot / Bar */}
             <span
-              className={`block rounded-full transition-all duration-300 ${
+              className={`block rounded-full transition-[width,height,background-color] duration-200 ${
                 isActive
                   ? `bg-primary ${isSub ? "w-5 h-[2px]" : "w-6 h-[2px]"}`
                   : `bg-muted-foreground/40 group-hover:bg-muted-foreground/70 ${

--- a/src/app/components/design-system.tsx
+++ b/src/app/components/design-system.tsx
@@ -13,32 +13,46 @@ export function SectionInner({
   className?: string;
 }) {
   return (
-    <div className={cn("relative z-10 max-w-5xl mx-auto", className)}>
+    <div className={cn("relative z-10 max-w-6xl mx-auto", className)}>
       {children}
     </div>
   );
 }
 
-/* ─── Section Heading (accent bar + heading) ─── */
+/* ─── Section Heading (ghost number + kicker + heading) ─── */
 
 export function SectionHeading({
   children,
   accent = "foreground",
   className,
+  sectionNumber,
+  kicker,
 }: {
   children: React.ReactNode;
   accent?: "primary" | "foreground";
   className?: string;
+  sectionNumber?: string;
+  kicker?: string;
 }) {
+  // accent prop은 기존 호환을 위해 유지 (하위 호환). 신규 시각은 ghost number/kicker 중심.
+  void accent;
   return (
-    <div className={cn("flex items-center gap-3 mb-4", className)}>
-      <div
-        className={cn(
-          "w-8 h-1 rounded-full",
-          accent === "primary" ? "bg-primary" : "bg-foreground"
-        )}
-      />
-      {children}
+    <div className={cn("relative mb-4", className)}>
+      {sectionNumber && (
+        <span
+          aria-hidden="true"
+          data-print-hide
+          className="absolute -top-10 -left-2 text-[8rem] leading-none font-black tracking-tightest text-foreground/[0.04] select-none pointer-events-none hidden md:block"
+        >
+          {sectionNumber}
+        </span>
+      )}
+      {kicker && (
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
+          {kicker}
+        </p>
+      )}
+      <div className="relative">{children}</div>
     </div>
   );
 }
@@ -71,7 +85,7 @@ export function ContentCard({
   return (
     <div
       className={cn(
-        "rounded-2xl bg-muted/30 border border-border",
+        "rounded-2xl bg-muted/30 border border-border shadow-editorial transition-shadow duration-200 hover:shadow-editorial-hover",
         paddingClass,
         className
       )}
@@ -86,7 +100,7 @@ export function ContentCard({
 export function FeatureItem({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/40 border border-border">
-      <div className="w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
+      <div className="w-1.5 h-1.5 rounded-full bg-foreground/60 shrink-0" />
       <span className="text-base font-medium text-foreground">{children}</span>
     </div>
   );
@@ -104,9 +118,9 @@ export function SubSectionTitle({
   className?: string;
 }) {
   const sizeClass = {
-    md: "text-lg font-bold tracking-snug",
-    lg: "text-2xl font-bold tracking-tight",
-    xl: "text-4xl font-bold tracking-tight",
+    md: "text-lg font-medium tracking-snug",
+    lg: "text-2xl font-semibold tracking-tight",
+    xl: "text-4xl font-bold tracking-tighter",
   }[size];
 
   return (
@@ -128,8 +142,8 @@ export function FeatureCard({
   className?: string;
 }) {
   return (
-    <div className={cn("p-5 rounded-xl bg-muted/40 border border-border", className)}>
-      <h6 className="text-base font-semibold text-foreground mb-2">{title}</h6>
+    <div className={cn("p-5 rounded-xl bg-muted/40 border border-border shadow-editorial transition-shadow duration-200 hover:shadow-editorial-hover", className)}>
+      <p className="text-base font-semibold text-foreground mb-2">{title}</p>
       <div className="text-sm-md font-normal text-muted-foreground leading-loose">{children}</div>
     </div>
   );
@@ -176,7 +190,7 @@ export function VerticalFlow({
           </div>
           {i < arr.length - 1 && (
             <div className="flex justify-center py-0.5">
-              <svg width="10" height="12" viewBox="0 0 10 12" className="text-border">
+              <svg width="10" height="12" viewBox="0 0 10 12" className="text-border" aria-hidden="true">
                 <path d="M5 0v8M2 6l3 4 3-4" fill="none" stroke="currentColor" strokeWidth="1.5" />
               </svg>
             </div>
@@ -243,14 +257,14 @@ export function IconButton({
   className?: string;
 } & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "className" | "children">) {
   const variantClass = {
-    primary: "bg-foreground hover:opacity-90 transition-opacity",
-    secondary: "border border-border text-foreground hover:bg-muted transition-colors",
+    primary: "bg-foreground hover:opacity-90 transition-[opacity,transform,background-color] duration-150 active:scale-[0.97]",
+    secondary: "border border-border text-foreground hover:bg-muted transition-[background-color,border-color,transform] duration-150 active:scale-[0.97]",
   }[variant];
 
   const sizeClass = {
-    sm: "gap-2 px-4 py-2 rounded-lg text-sm-md",
-    md: "gap-2 px-5 py-2.5 rounded-full text-base",
-    lg: "gap-3 px-6 py-3 rounded-xl text-base",
+    sm: "gap-2 px-4 py-2 rounded-lg text-sm-md min-h-[44px]",
+    md: "gap-2 px-5 py-2.5 rounded-full text-base min-h-[44px]",
+    lg: "gap-3 px-6 py-3 rounded-xl text-base min-h-[44px]",
   }[size];
 
   const variantStyle = variant === "primary" ? { color: "var(--background)" } : undefined;
@@ -258,7 +272,7 @@ export function IconButton({
   return (
     <a
       href={href}
-      className={cn("inline-flex items-center font-medium", variantClass, sizeClass, className)}
+      className={cn("inline-flex items-center justify-center font-medium", variantClass, sizeClass, className)}
       style={variantStyle}
       {...rest}
     >
@@ -280,7 +294,7 @@ export function NumberedStep({
   return (
     <div className="p-5 rounded-xl bg-muted/40 border border-border">
       <div className="flex items-start gap-3">
-        <span className="shrink-0 w-6 h-6 rounded-full bg-primary/10 text-primary text-xs font-semibold flex items-center justify-center mt-0.5">
+        <span className="shrink-0 w-6 h-6 rounded-full bg-primary/10 text-primary text-xs font-black tabular-nums flex items-center justify-center mt-0.5">
           {index}
         </span>
         <p className="text-sm-md font-normal text-foreground leading-loose">{children}</p>
@@ -295,13 +309,21 @@ export function TwoColumnLayout({
   left,
   right,
   className,
+  ratio = "1:1",
 }: {
   left: React.ReactNode;
   right: React.ReactNode;
   className?: string;
+  ratio?: "1:1" | "3:2" | "2:3";
 }) {
+  const ratioClass = {
+    "1:1": "md:grid-cols-2",
+    "3:2": "md:grid-cols-[3fr_2fr]",
+    "2:3": "md:grid-cols-[2fr_3fr]",
+  }[ratio];
+
   return (
-    <div className={cn("grid md:grid-cols-2 gap-8 items-start", className)}>
+    <div className={cn("grid gap-8 items-start", ratioClass, className)}>
       {left}
       {right}
     </div>
@@ -428,7 +450,7 @@ export function SectionPageHeading({
     <FadeInView speed={1.2}>
       <div className="mb-16">
         <SectionHeading accent={accent}>
-          <h2 className="text-6xl font-bold tracking-tighter leading-snug text-foreground">
+          <h2 className="text-6xl font-black tracking-tighter leading-[0.95] text-foreground text-balance">
             {children}
           </h2>
         </SectionHeading>

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -38,7 +38,7 @@
 
   /* 프로젝트 인트로 디바이더(수평선 확장 애니메이션 블록) 제거 — 본문에
      이미 프로젝트 번호+타이틀이 있으므로 인쇄용에서는 중복이자 공백 원인 */
-  #project-01, #project-02, #project-03, #project-04 {
+  #project-01, #project-02, #project-03, #project-04, #project-05 {
     display: none !important;
   }
 
@@ -87,7 +87,8 @@ html.print-mode [data-print-hide] { display: none !important; }
 html.print-mode #project-01,
 html.print-mode #project-02,
 html.print-mode #project-03,
-html.print-mode #project-04 { display: none !important; }
+html.print-mode #project-04,
+html.print-mode #project-05 { display: none !important; }
 
 /* print-mode: 테마 배경/장식 레이어 제거 (브라우저 ?print=1 미리보기용) */
 html.print-mode { background: transparent !important; }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -2,27 +2,29 @@
 
 :root {
   --font-size: 16px;
-  --background: #fafafa;
-  --foreground: #1a1a2e;
-  --card: #ffffff;
-  --card-foreground: #1a1a2e;
-  --popover: #ffffff;
-  --popover-foreground: #1a1a2e;
-  --primary: #2563eb;
-  --primary-foreground: #ffffff;
-  --secondary: #f1f5f9;
-  --secondary-foreground: #1a1a2e;
-  --muted: #f1f5f9;
-  --muted-foreground: #64748b;
-  --accent: #e0e7ff;
-  --accent-foreground: #1e40af;
+  /* ===== Editorial palette — Vermilion × Cream × Espresso (Light) ===== */
+  --background: #FAF8F4;
+  --foreground: #1C1510;
+  --card: #FFFFFE;
+  --card-foreground: #1C1510;
+  --popover: #FFFFFE;
+  --popover-foreground: #1C1510;
+  --primary: #C0392B;
+  --primary-foreground: #FAF8F4;
+  --secondary: #EDE6D6;
+  --secondary-foreground: #1C1510;
+  --muted: #EDE6D6;
+  --muted-foreground: #6B5D4F;
+  --accent: #F0E4D0;
+  --accent-foreground: #1C1510;
   --destructive: #ef4444;
   --destructive-foreground: #ffffff;
-  --border: rgba(0, 0, 0, 0.08);
+  --border: #DDD5C5;
+  --border-hairline: rgba(28, 21, 16, 0.08);
   --input: transparent;
-  --input-background: #f3f3f5;
-  --switch-background: #cbced4;
-  --ring: oklch(0.708 0 0);
+  --input-background: #F0E4D0;
+  --switch-background: #DDD5C5;
+  --ring: #C0392B;
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -37,28 +39,32 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+
+  /* ===== Motion easing ===== */
+  --ease-editorial: cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .dark {
-  --background: #0f0f1a;
-  --foreground: #e2e8f0;
-  --card: #1a1a2e;
-  --card-foreground: #e2e8f0;
-  --popover: #1a1a2e;
-  --popover-foreground: #e2e8f0;
-  --primary: #60a5fa;
-  --primary-foreground: #0f0f1a;
-  --secondary: #1e293b;
-  --secondary-foreground: #e2e8f0;
-  --muted: #1e293b;
-  --muted-foreground: #94a3b8;
-  --accent: #1e3a5f;
-  --accent-foreground: #93c5fd;
+  --background: #111009;
+  --foreground: #EDE8E0;
+  --card: #1A1712;
+  --card-foreground: #EDE8E0;
+  --popover: #1A1712;
+  --popover-foreground: #EDE8E0;
+  --primary: #E74C3C;
+  --primary-foreground: #111009;
+  --secondary: #201D18;
+  --secondary-foreground: #EDE8E0;
+  --muted: #201D18;
+  --muted-foreground: #A89B8A;
+  --accent: #2A2218;
+  --accent-foreground: #EDE8E0;
   --destructive: #ef4444;
   --destructive-foreground: #ffffff;
-  --border: rgba(255, 255, 255, 0.08);
-  --input: #1e293b;
-  --ring: oklch(0.439 0 0);
+  --border: #2A2620;
+  --border-hairline: rgba(237, 232, 224, 0.1);
+  --input: #201D18;
+  --ring: #E74C3C;
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
@@ -93,6 +99,7 @@
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-border: var(--border);
+  --color-border-hairline: var(--border-hairline);
   --color-input: var(--input);
   --color-input-background: var(--input-background);
   --color-switch-background: var(--switch-background);
@@ -117,26 +124,26 @@
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
 
-  /* ===== Typography - Font Size ===== */
-  --text-4xs: 7px;
-  --text-3xs: 8px;
-  --text-2xs: 9px;
-  --text-xxs: 10px;
-  --text-xs: 11px;
-  --text-sm: 12px;
-  --text-sm-md: 13px;
-  --text-base: 14px;
-  --text-md: 15px;
-  --text-lg: 16px;
-  --text-xl: 17px;
-  --text-2xl: 18px;
-  --text-3xl: 20px;
-  --text-4xl: 22px;
-  --text-5xl: 28px;
-  --text-6xl: 32px;
-  --text-7xl: 36px;
-  --text-8xl: 48px;
-  --text-9xl: 72px;
+  /* ===== Typography - Font Size (rem 전환) ===== */
+  --text-4xs: 0.4375rem;   /* 7px */
+  --text-3xs: 0.5rem;      /* 8px */
+  --text-2xs: 0.5625rem;   /* 9px */
+  --text-xxs: 0.625rem;    /* 10px */
+  --text-xs: 0.75rem;      /* 12px */
+  --text-sm: 0.8125rem;    /* 13px */
+  --text-sm-md: 0.8125rem; /* 13px */
+  --text-base: 0.875rem;   /* 14px */
+  --text-md: 0.9375rem;    /* 15px */
+  --text-lg: 0.9375rem;    /* 15px */
+  --text-xl: 1rem;         /* 16px */
+  --text-2xl: 1.125rem;    /* 18px */
+  --text-3xl: 1.25rem;     /* 20px */
+  --text-4xl: 1.5rem;      /* 24px */
+  --text-5xl: 1.875rem;    /* 30px */
+  --text-6xl: 2.25rem;     /* 36px */
+  --text-7xl: 3rem;        /* 48px */
+  --text-8xl: 4.5rem;      /* 72px */
+  --text-9xl: 6rem;        /* 96px */
 
   /* ===== Typography - Font Weight ===== */
   --font-weight-normal: 400;
@@ -147,12 +154,12 @@
   --font-weight-black: 900;
 
   /* ===== Typography - Letter Spacing ===== */
-  --tracking-tightest: -0.04em;
-  --tracking-tighter: -0.03em;
-  --tracking-tight: -0.02em;
+  --tracking-tightest: -0.055em;
+  --tracking-tighter: -0.025em;
+  --tracking-tight: -0.015em;
   --tracking-snug: -0.01em;
   --tracking-normal: 0em;
-  --tracking-wide: 0.02em;
+  --tracking-wide: 0.08em;
   --tracking-wider: 0.05em;
   --tracking-widest: 0.08em;
 
@@ -163,6 +170,9 @@
   --leading-normal: 1.5;
   --leading-relaxed: 1.625;
   --leading-loose: 1.8;
+
+  /* ===== Motion easing ===== */
+  --ease-editorial: var(--ease-editorial);
 }
 
 @layer base {
@@ -184,7 +194,14 @@
     font-size: var(--font-size);
     font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
     letter-spacing: -0.02em;
-    scroll-behavior: smooth;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    html {
+      scroll-behavior: smooth;
+    }
   }
 
   h1 {
@@ -227,5 +244,71 @@
     font-size: var(--text-base);
     font-weight: var(--font-weight-normal);
     line-height: 1.5;
+  }
+
+  /* Focus ring — 전역 접근성 */
+  :focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  /* 이미지 기본 hairline outline */
+  img {
+    outline: 1px solid rgba(28, 21, 16, 0.06);
+    outline-offset: -1px;
+  }
+}
+
+.dark img {
+  outline-color: rgba(237, 232, 224, 0.08);
+}
+
+@media print {
+  img {
+    outline: none;
+  }
+}
+
+/* 전역 reduced-motion 처리 */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+@layer utilities {
+  .shadow-editorial {
+    box-shadow:
+      0 1px 2px rgba(28, 21, 16, 0.04),
+      0 4px 12px rgba(28, 21, 16, 0.06),
+      0 16px 32px rgba(28, 21, 16, 0.04);
+  }
+  .shadow-editorial-hover {
+    box-shadow:
+      0 2px 4px rgba(28, 21, 16, 0.06),
+      0 8px 24px rgba(28, 21, 16, 0.08),
+      0 24px 48px rgba(28, 21, 16, 0.06);
+  }
+  .dark .shadow-editorial {
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.4),
+      0 4px 12px rgba(0, 0, 0, 0.3),
+      0 16px 32px rgba(0, 0, 0, 0.2);
+  }
+  .dark .shadow-editorial-hover {
+    box-shadow:
+      0 2px 4px rgba(0, 0, 0, 0.5),
+      0 8px 24px rgba(0, 0, 0, 0.4),
+      0 24px 48px rgba(0, 0, 0, 0.3);
   }
 }


### PR DESCRIPTION
## Summary

사용자가 설치한 5개 디자인 스킬(frontend-design · make-interfaces-feel-better · emil-design-eng · web-design-guidelines · ui-ux-pro-max)을 렌즈로 포트폴리오를 Editorial 매거진 톤으로 전면 개편.

### Wave 구조 (멀티 에이전트)
- **Wave 1 감사**: 5개 스킬 병렬 리포트
- **Wave 2 Design Spec v2**: Opus DirectorOpus가 팔레트/스케일/모션 프리셋/접근성 스펙 확정
- **Wave 3 파운데이션**: 토큰·프리미티브·모션 리빌드
- **Wave 4 섹션**: Hero/Nav/Footer/Indicator · About/Profile/Experience · Projects + ShowPot 활성화
- **Wave 5~6**: Vercel CI에서 PDF 회귀 자동 검증

### 디자인 방향 (사용자 확정)
- Editorial 매거진 톤, "개발자스럽지 않게"
- **Pretendard 유지** (신규 폰트 도입 없음), weight 대비 900↔100로 위계
- 주홍 `#C0392B`(라이트)/`#E74C3C`(다크) × 크림 `#FAF8F4`/`#111009` × 에스프레소 `#1C1510`/`#EDE8E0`

### 변경 카테고리

**1. 토큰 (theme.css, index.html)**
- 팔레트: 파랑 `#2563eb` → 주홍 `#C0392B` / 배경·전경 크림-에스프레소로 전환
- 타입스케일 전체 rem 전환 (4xs~9xl)
- `--text-9xl` 72→96px, `--text-8xl` 48→72px
- `--tracking-tightest` -0.04em→-0.055em
- 신규: `--border-hairline`, `--ease-editorial`, `--tracking-wide`
- 전역: `-webkit-font-smoothing: antialiased`, `:focus-visible` 링, `@media (prefers-reduced-motion)`, 이미지 outline, `shadow-editorial/-hover` 유틸
- `lang="en"` → `lang="ko"`, `color-scheme`·`theme-color`(light/dark), CDN preconnect

**2. 프리미티브 (design-system.tsx, ParallaxSection.tsx)**
- SectionInner: `max-w-5xl` → `max-w-6xl`
- SectionHeading: 색 바 제거, `sectionNumber`/`kicker` 옵션 prop 추가 (ghost 번호, `data-print-hide`)
- ContentCard/FeatureCard: `shadow-editorial` 적용 + hover shadow
- FeatureCard: `<h6>` 오용 → `<p>` 시맨틱 개선
- FeatureItem: primary dot → `foreground/60` (차분화)
- IconButton: `min-h-[44px]` 터치 타겟, `active:scale-[0.97]` press feedback, transition 속성 명시
- NumberedStep: 숫자 `tabular-nums`
- TwoColumnLayout: `ratio` prop (1:1/3:2/2:3) 추가
- VerticalFlow: 장식 SVG `aria-hidden`
- SectionPageHeading: `font-black` + `text-balance`
- SubSectionTitle: weight 위계 분리
- 신규 export: `useEditorialMotion()` — easing/spring/reduced-motion 단일 프리셋
- FadeInView/ScrollSection/DeepParallax 전체 `prefers-reduced-motion` 대응 + 스프링 튜닝(stiffness 120→140, damping 30→28), y 거리 50→24

**3. 섹션**
- Hero: 중앙정렬 → `[3fr_2fr]` 비대칭 / h1 `font-black` + `clamp(3.5rem, 14vw, 9rem)` / 진입 800ms 캐스케이드 → 450ms + 80ms 간격 / 서브 `font-light`로 weight 대비 / 장식 aria-hidden
- Navigation: 아이콘 버튼 44px 터치 + aria-label 한국어 / 햄버거 `aria-expanded` + `aria-controls` + Esc 닫기 + 포커스 복귀 / transition-all → 구체 속성
- Footer: "Let's Connect" `font-black` + `text-balance` / 전화번호 `tel:` 링크 + tabular-nums + 44px / kicker 추가
- SectionIndicator: `project-05` 추가 / `aria-current="location"` / 44px hit area / transition-all → 구체
- About: kicker + ghost 번호 "01" / h2 font-bold→font-black + text-balance / 3카드 `[2fr_1.5fr_1fr]` 비대칭 / Contact info `tel:` 링크 + tabular-nums + aria-label / 프로필 alt 구체화
- Profile: kicker "Section 02" / 2컬럼 1:1→2fr:3fr / 이름 font-black / InfoRow external/tabular props + aria-label
- Experience: kicker "Section 03" / 회사명 font-black / 기간 tabular-nums
- Projects (ProjectHeader): 번호 tabular-nums + aria-hidden / title font-black + text-balance / 버튼 aria-label
- App.tsx: ProjectShowPot 활성화 + ProjectDivider `#project-05` / max-w-5xl→max-w-6xl / ScrollProgress aria-hidden
- print.css: `#project-05` 숨김 규칙 추가

### PDF 계약 준수
- ✅ `bg-background`/`bg-muted`/`blur-xl/2xl/3xl`/`rounded-xl+border-border`/`rounded-2xl+border-border`/`sticky`/`h-screen` 클래스명 보존
- ✅ `data-print-keep`/`data-print-hide` 기존 위치 유지
- ✅ "더보기"/"펼치" 버튼 라벨 유지
- ✅ `scripts/*.mjs` 수정 없음
- ✅ 섹션 삭제/추가/순서변경 없음, 콘텐츠 삭제 없음
- ✅ ShowPot 추가 시 `#project-05` + print.css 동기 패치

## Test plan
- [x] `npm run build` 성공 (타입/번들 에러 0)
- [ ] Vercel 배포에서 `npm run build:pdf` 성공 확인 (로컬 워크트리 node_modules 부재로 로컬에서는 확인 불가)
- [ ] 라이트/다크 모드 각 섹션 렌더 확인
- [ ] 375/768/1280 뷰포트 확인
- [ ] `prefers-reduced-motion` 에뮬레이션에서 패럴랙스 비활성
- [ ] 키보드 Tab 순서 및 포커스 링 가시성
- [ ] PDF: Hero 다운로드 버튼/Nav/인트로 divider(project-01~05)/Experience 더보기 자동 확장 확인
- [ ] PDF: 라이트 모드 잉크 대비, 장식 blur 미노출, 카드 페이지 절단 없음

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)